### PR TITLE
Don't hide help_hidden

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -118,7 +118,7 @@ def help : Flag<["-", "--"], "help">,
   HelpText<"Display available options">;
 def h : Flag<["-"], "h">, Alias<help>;
 def help_hidden : Flag<["-", "--"], "help-hidden">,
-  Flags<[HelpHidden, FrontendOption]>,
+  Flags<[FrontendOption]>,
   HelpText<"Display available options, including hidden options">;
 
 def v : Flag<["-"], "v">, Flags<[DoesNotAffectIncrementalBuild]>,


### PR DESCRIPTION
Currently it's not possible to find out about hidden options without looking at the source.
At least the help_hidden option should be visible to let users know about the existence of hidden options.
